### PR TITLE
Add str borrowing and fix hash calculation bug

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -98,6 +98,12 @@ impl AsRef<str> for IString {
     }
 }
 
+impl std::borrow::Borrow<str> for IString {
+    fn borrow(&self) -> &str {
+        &*self
+    }
+}
+
 #[cfg(test)]
 mod test_string {
     use super::*;


### PR DESCRIPTION
Hashes of the `IString::Static("foo")` and `IString::Rc(Rc::from("foo"))` do not match. This is confusing when using an `HashMap`. 