### PR TITLE
Impl ImplicitClone for tuples up to 12 items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,4 @@ rustdoc-args = ["--cfg", "docsrs"]
 map = ["indexmap"]
 
 [dependencies]
-impl-trait-for-tuples = "0.2"
 indexmap = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 map = ["indexmap"]
 
 [dependencies]
+impl-trait-for-tuples = "0.2"
 indexmap = { version = "1", optional = true }

--- a/src/array.rs
+++ b/src/array.rs
@@ -250,4 +250,10 @@ mod test_array {
     fn deref_slice() {
         assert!(IArray::Static(&[1, 2, 3]).contains(&1));
     }
+
+    #[test]
+    fn tuple_in_array() {
+        const _ARRAY_2: IArray<(u32, u32)> = IArray::Static(&[]);
+        const _ARRAY_5: IArray<(u32, u32, u32, u32, u32)> = IArray::Static(&[]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod unsync;
 ///
 /// Behaves exactly like [`Copy`] but calls the [`Clone`] implementation instead and must be
 /// implemented in the host library.
+#[impl_trait_for_tuples::impl_for_tuples(5)]
 pub trait ImplicitClone: Clone {}
 
 impl<T: ImplicitClone> ImplicitClone for Option<T> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,6 @@ pub mod unsync;
 ///
 /// Behaves exactly like [`Copy`] but calls the [`Clone`] implementation instead and must be
 /// implemented in the host library.
-#[impl_trait_for_tuples::impl_for_tuples(5)]
 pub trait ImplicitClone: Clone {}
 
 impl<T: ImplicitClone> ImplicitClone for Option<T> {}
@@ -62,6 +61,24 @@ impl_implicit_clone!(
     f32, f64,
     &'static str,
 );
+
+macro_rules! impl_implicit_clone_for_tuple {
+    ($($param:ident),+) => {
+        impl<$($param: ImplicitClone),+> ImplicitClone for ($($param),+) {}
+    };
+}
+
+impl_implicit_clone_for_tuple!(T1, T2);
+impl_implicit_clone_for_tuple!(T1, T2, T3);
+impl_implicit_clone_for_tuple!(T1, T2, T3, T4);
+impl_implicit_clone_for_tuple!(T1, T2, T3, T4, T5);
+impl_implicit_clone_for_tuple!(T1, T2, T3, T4, T5, T6);
+impl_implicit_clone_for_tuple!(T1, T2, T3, T4, T5, T6, T7);
+impl_implicit_clone_for_tuple!(T1, T2, T3, T4, T5, T6, T7, T8);
+impl_implicit_clone_for_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9);
+impl_implicit_clone_for_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
+impl_implicit_clone_for_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
+impl_implicit_clone_for_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
 
 /// A macro to help deconstructs maps inspired by JS.
 ///


### PR DESCRIPTION
- Implement ImplicitClone for tuples
- Reduce number of dependencies and increase tuples to 12 items
