### PR TITLE
Implement ImplicitClone for char

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ impl_implicit_clone!(
     f32, f64,
     bool,
     usize, isize,
-    &'static str,
+    &'static str, char,
     (),
 );
 


### PR DESCRIPTION
Any primitive type that implements Copy should also implement ImplicitClone. It
would be nice if it was possible to tell Rust that but I couldn't manage to do
it. If anyone wants to give it a try...

https://github.com/yewstack/implicit-clone/pull/9#issuecomment-1198598528

In the meantime, here is a small PR for adding char so it's possible to make a
type `IArray<char>`.
