### PR TITLE
Add implementation for single-item tuples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ macro_rules! impl_implicit_clone_for_tuple {
     };
 }
 
-impl_implicit_clone_for_tuple!(T1, );
+impl_implicit_clone_for_tuple!(T1,);
 impl_implicit_clone_for_tuple!(T1, T2);
 impl_implicit_clone_for_tuple!(T1, T2, T3);
 impl_implicit_clone_for_tuple!(T1, T2, T3, T4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,12 @@ impl_implicit_clone!(
 );
 
 macro_rules! impl_implicit_clone_for_tuple {
-    ($($param:ident),+) => {
-        impl<$($param: ImplicitClone),+> ImplicitClone for ($($param),+) {}
+    ($($param:ident),+ $(,)?) => {
+        impl<$($param: ImplicitClone),+> ImplicitClone for ($($param,)+) {}
     };
 }
 
+impl_implicit_clone_for_tuple!(T1, );
 impl_implicit_clone_for_tuple!(T1, T2);
 impl_implicit_clone_for_tuple!(T1, T2, T3);
 impl_implicit_clone_for_tuple!(T1, T2, T3, T4);


### PR DESCRIPTION
Assuming the `T2`-`T12` tuple `impl` enumeration matches [`impl From<(...)> for [T; ...]`](https://doc.rust-lang.org/std/primitive.array.html), current code misses not so obvious single-item tuple [`(T1,)`](https://doc.rust-lang.org/std/primitive.array.html#impl-From%3C(T,)%3E-for-%5BT;+1%5D).

The style (trailing comma) of writing single-item tuple in the `impl` is made to be the same as actual single-item tuple syntax (although did not really have to be), macro associated with this also was changed, to allow for single-item tuple (change turns `(A, B, C)` into `(A, B, C,)`, which is the same type for all tuples except single-item`) and its trailing comma syntax.