### PR TITLE
Use mod paths instead of include

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -1,3 +1,8 @@
+use std::fmt;
+
+use super::Rc;
+use crate::ImplicitClone;
+
 /// An immutable array type inspired by [Immutable.js](https://immutable-js.com/).
 ///
 /// This type is cheap to clone and thus implements [`ImplicitClone`]. It can be created based on a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![allow(clippy::unnecessary_lazy_evaluations)]
+#![allow(clippy::duplicate_mod)]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))

--- a/src/map.rs
+++ b/src/map.rs
@@ -3,7 +3,13 @@ use indexmap::map::Keys as MapKeys;
 use indexmap::map::Values as MapValues;
 use indexmap::IndexMap as Map;
 use std::borrow::Borrow;
+use std::fmt;
 use std::hash::Hash;
+
+use crate::ImplicitClone;
+
+use super::IString;
+use super::Rc;
 
 /// An immutable hash map type inspired by [Immutable.js](https://immutable-js.com/).
 ///
@@ -346,7 +352,7 @@ where
                 for (k, v) in a.iter() {
                     seq.serialize_entry(k, v)?;
                 }
-            },
+            }
             Self::Rc(a) => {
                 for (k, v) in a.iter() {
                     seq.serialize_entry(k, v)?;

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,7 +1,11 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::str::FromStr;
+
+use crate::ImplicitClone;
+
+use super::Rc;
 
 /// An immutable string type inspired by [Immutable.js](https://immutable-js.com/).
 ///

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,11 +1,18 @@
+use std::sync::Arc as Rc;
+
 use crate::ImplicitClone;
-use std::fmt;
 
-type Rc<T> = std::sync::Arc<T>;
-
-include!("string.rs");
-include!("array.rs");
+#[path = "array.rs"]
+mod array;
 #[cfg(feature = "map")]
-include!("map.rs");
+#[path = "map.rs"]
+mod map;
+#[path = "string.rs"]
+mod string;
+
+pub use array::IArray;
+#[cfg(feature = "map")]
+pub use map::IMap;
+pub use string::IString;
 
 impl<T: ?Sized> ImplicitClone for Rc<T> {}

--- a/src/unsync.rs
+++ b/src/unsync.rs
@@ -1,10 +1,18 @@
-use crate::ImplicitClone;
-use std::fmt;
 use std::rc::Rc;
 
-include!("string.rs");
-include!("array.rs");
+use crate::ImplicitClone;
+
+#[path = "array.rs"]
+mod array;
 #[cfg(feature = "map")]
-include!("map.rs");
+#[path = "map.rs"]
+mod map;
+#[path = "string.rs"]
+mod string;
+
+pub use array::IArray;
+#[cfg(feature = "map")]
+pub use map::IMap;
+pub use string::IString;
 
 impl<T: ?Sized> ImplicitClone for Rc<T> {}


### PR DESCRIPTION
This approach still allows using the same files for Rc and Arc while preventing imports from leaking as well as working better with rust-analyzer.