### PR TITLE
string: add impl From<&IString> for IString

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -67,6 +67,12 @@ impl<T: ImplicitClone + 'static> From<Rc<[T]>> for IArray<T> {
     }
 }
 
+impl<T: ImplicitClone + 'static> From<&IArray<T>> for IArray<T> {
+    fn from(a: &IArray<T>) -> IArray<T> {
+        a.clone()
+    }
+}
+
 impl<T: ImplicitClone + 'static> IArray<T> {
     /// Returns an iterator over the slice.
     ///
@@ -355,5 +361,11 @@ mod test_array {
     fn floats_in_array() {
         const _ARRAY_F32: IArray<f32> = IArray::Static(&[]);
         const _ARRAY_F64: IArray<f64> = IArray::Static(&[]);
+    }
+
+    #[test]
+    fn from() {
+        let x: IArray<u32> = IArray::Static(&[]);
+        let _out = IArray::from(&x);
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -99,6 +99,14 @@ impl<K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'sta
     }
 }
 
+impl<K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'static>
+    From<&IMap<K, V>> for IMap<K, V>
+{
+    fn from(a: &IMap<K, V>) -> IMap<K, V> {
+        a.clone()
+    }
+}
+
 impl<K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'static> IMap<K, V> {
     /// Return an iterator over the key-value pairs of the map, in their order.
     #[inline]
@@ -424,5 +432,11 @@ mod test_map {
     fn floats_in_map() {
         const _MAP_F32: IMap<u32, f32> = IMap::Static(&[]);
         const _MAP_F64: IMap<u32, f64> = IMap::Static(&[]);
+    }
+
+    #[test]
+    fn from() {
+        let x: IMap<u32, u32> = IMap::Static(&[]);
+        let _out = IMap::from(&x);
     }
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -96,6 +96,12 @@ impl From<Cow<'static, str>> for IString {
     }
 }
 
+impl From<&IString> for IString {
+    fn from(s: &IString) -> IString {
+        s.clone()
+    }
+}
+
 macro_rules! impl_cmp_as_str {
     (PartialEq::<$type1:ty, $type2:ty>) => {
         impl_cmp_as_str!(PartialEq::<$type1, $type2>::eq -> bool);
@@ -393,5 +399,11 @@ mod test_string {
 
         // this assert exists to ensure the cow lives after the strong_count assert
         assert_eq!(cow, "foo");
+    }
+
+    #[test]
+    fn from_ref() {
+        let s = IString::Static("foo");
+        let _out = IString::from(&s);
     }
 }


### PR DESCRIPTION
I just notice that this is possible with String but not with IString:

```
let x = String::from("foo");
let y = String::from(&x);

let x = IString::Static("foo");
let y = IString::from(&x);
```

I get this issue while using Yew that could be fixed that way:

```
error[E0277]: the trait bound `implicit_clone::unsync::IString: From<&implicit_clone::unsync::IString>` is not satisfied
   --> packages/yew/src/html/conversion/into_prop_value.rs:298:28
    |
298 |                 VText::new(self).into()
    |                 ---------- ^^^^ the trait `From<&implicit_clone::unsync::IString>` is not implemented for `implicit_clone::unsync::IString`
    |                 |
    |                 required by a bound introduced by this call
```
