### PR TITLE
IArray: avoid heap allocation if there is only one element

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -216,7 +216,8 @@ impl<T: ImplicitClone + 'static> IArray<T> {
     pub fn get_mut(&mut self) -> Option<&mut [T]> {
         match self {
             Self::Rc(ref mut rc) => Rc::get_mut(rc),
-            Self::Static(_) | Self::Single(_) => None,
+            Self::Static(_) => None,
+            Self::Single(ref mut a) => Some(a),
         }
     }
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -399,14 +399,12 @@ mod test_array {
 
     #[test]
     fn from() {
-<<<<<<< HEAD
+        let x: IArray<u32> = IArray::Static(&[]);
+        let _out = IArray::from(&x);
+
         let _array: IArray<u32> = IArray::from(&[1, 2, 3][..]);
         let _array: IArray<u32> = IArray::from(vec![1, 2, 3]);
         let _array: IArray<u32> = IArray::from(Rc::from(vec![1, 2, 3]));
         let _array: IArray<u32> = IArray::from([1]);
-=======
-        let x: IArray<u32> = IArray::Static(&[]);
-        let _out = IArray::from(&x);
->>>>>>> ac2980922528800310ba333512fa6368ce02410f
     }
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -205,6 +205,10 @@ impl<T: ImplicitClone + 'static> IArray<T> {
     /// // Static references are immutable
     /// let mut v3 = IArray::<u8>::Static(&[1,2,3]);
     /// assert!(v3.get_mut().is_none());
+    ///
+    /// // Single items always return a mutable reference
+    /// let mut v4 = IArray::<u8>::Single([1]);
+    /// assert!(v4.get_mut().is_some());
     /// ```
     #[inline]
     pub fn get_mut(&mut self) -> Option<&mut [T]> {

--- a/src/array.rs
+++ b/src/array.rs
@@ -71,12 +71,6 @@ impl<T: ImplicitClone + 'static> From<Rc<[T]>> for IArray<T> {
     }
 }
 
-impl<T: ImplicitClone + 'static> From<T> for IArray<T> {
-    fn from(x: T) -> IArray<T> {
-        IArray::Single([x])
-    }
-}
-
 impl<T: ImplicitClone + 'static> From<[T; 1]> for IArray<T> {
     fn from(a: [T; 1]) -> IArray<T> {
         IArray::Single(a)
@@ -398,7 +392,6 @@ mod test_array {
         let _array: IArray<u32> = IArray::from(&[1, 2, 3][..]);
         let _array: IArray<u32> = IArray::from(vec![1, 2, 3]);
         let _array: IArray<u32> = IArray::from(Rc::from(vec![1, 2, 3]));
-        let _array: IArray<u32> = IArray::from(1);
         let _array: IArray<u32> = IArray::from([1]);
     }
 }


### PR DESCRIPTION
Working on Yew at the moment and I would like to refactor NodeSeq to use
IArray. It already works as is but I thought it would be nice if we could avoid
unnecessary allocations, particularly when there is only one item in the array.
