### PR TITLE
Remove opaque type on function iter() of IArray

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -83,6 +83,7 @@ impl<T: ImplicitClone + 'static> From<[T; 1]> for IArray<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct Iter<T: ImplicitClone + 'static> {
     array: IArray<T>,
     index: usize,

--- a/src/array.rs
+++ b/src/array.rs
@@ -83,6 +83,27 @@ impl<T: ImplicitClone + 'static> From<[T; 1]> for IArray<T> {
     }
 }
 
+pub struct Iter<T: ImplicitClone + 'static> {
+    array: IArray<T>,
+    index: usize,
+}
+
+impl<T: ImplicitClone + 'static> Iter<T> {
+    fn new(array: IArray<T>) -> Self {
+        Self { array, index: 0 }
+    }
+}
+
+impl<T: ImplicitClone + 'static> Iterator for Iter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self.array.get(self.index);
+        self.index += 1;
+        item
+    }
+}
+
 impl<T: ImplicitClone + 'static> IArray<T> {
     /// Returns an iterator over the slice.
     ///
@@ -99,12 +120,8 @@ impl<T: ImplicitClone + 'static> IArray<T> {
     /// assert_eq!(iterator.next(), None);
     /// ```
     #[inline]
-    pub fn iter(&self) -> impl Iterator<Item = T> + '_ {
-        match self {
-            Self::Static(a) => a.iter().cloned(),
-            Self::Rc(a) => a.iter().cloned(),
-            Self::Single(a) => a.iter().cloned(),
-        }
+    pub fn iter(&self) -> Iter<T> {
+        Iter::new(self.clone())
     }
 
     /// Returns the number of elements in the vector, also referred to


### PR DESCRIPTION
This change is necessary for me to work on NodeSeq on Yew as there is an trait
there that is impossible to implement if the iter() method here returns an
opaque type.

```patch
-impl<IN, OUT> IntoIterator for NodeSeq<IN, OUT> {
+impl<IN, OUT: ImplicitClone + 'static> IntoIterator for NodeSeq<IN, OUT> {
     type IntoIter = std::vec::IntoIter<Self::Item>; // this should be the "Iter" type of IArray
     type Item = OUT;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.0.iter().collect::<Vec<_>>().into_iter() // terrible temporary workaround
     }
 }
```