### PR TITLE
Add derive macro to get ImplicitClone implemented quicker

### DIFF
--- a/implicit-clone-derive/Cargo.toml
+++ b/implicit-clone-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "implicit-clone"
-version = "0.4.6"
+name = "implicit-clone-derive"
+version = "0.1.0"
 authors = ["Cecile Tonglet <cecile.tonglet@cecton.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -13,20 +13,14 @@ keywords = ["immutable", "cheap-clone", "copy", "rc"]
 categories = ["rust-patterns"]
 rust-version = "1.64"
 
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-
-[features]
-default = ["derive"]
-map = ["indexmap"]
-serde = ["dep:serde", "indexmap/serde"]
-derive = ["implicit-clone-derive"]
+[lib]
+proc-macro = true
 
 [dependencies]
-implicit-clone-derive = { version = "0.1", optional = true, path = "./implicit-clone-derive" }
-indexmap = { version = ">= 1, <= 2", optional = true }
-serde = { version = "1", optional = true }
+quote = "1"
+syn = { version = "2", features = ["full"] }
 
-[workspace]
-members = ["implicit-clone-derive"]
+[dev-dependencies]
+implicit-clone = { path = ".." }
+trybuild = "1"
+rustversion = "1"

--- a/implicit-clone-derive/src/lib.rs
+++ b/implicit-clone-derive/src/lib.rs
@@ -2,9 +2,43 @@ use quote::quote;
 
 #[proc_macro_derive(ImplicitClone)]
 pub fn derive_implicit_clone(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let syn::ItemStruct { ident, .. } = syn::parse_macro_input!(item as syn::ItemStruct);
+    let syn::ItemStruct {
+        ident, generics, ..
+    } = syn::parse_macro_input!(item as syn::ItemStruct);
+    let (_impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let generics = generics
+        .params
+        .iter()
+        .map(|param| match param {
+            syn::GenericParam::Type(syn::TypeParam {
+                attrs,
+                ident,
+                colon_token: _,
+                bounds,
+                eq_token,
+                default,
+            }) => {
+                let bounds = bounds
+                    .iter()
+                    .map(|bound| quote! { #bound })
+                    .chain(std::iter::once(quote! { ::implicit_clone::ImplicitClone }))
+                    .collect::<Vec<_>>();
+                quote! {
+                    #(#attrs)* #ident: #(#bounds)+* #eq_token #default
+                }
+            }
+            _ => quote! { #param },
+        })
+        .collect::<Vec<_>>();
+    let generics = if generics.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            <#(#generics),*>
+        }
+    };
     let res = quote! {
-        impl ::implicit_clone::ImplicitClone for #ident {}
+        impl #generics ::implicit_clone::ImplicitClone for #ident #ty_generics #where_clause {}
     };
     res.into()
 }

--- a/implicit-clone-derive/src/lib.rs
+++ b/implicit-clone-derive/src/lib.rs
@@ -1,0 +1,10 @@
+use quote::quote;
+
+#[proc_macro_derive(ImplicitClone)]
+pub fn derive_implicit_clone(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let syn::ItemStruct { ident, .. } = syn::parse_macro_input!(item as syn::ItemStruct);
+    let res = quote! {
+        impl ::implicit_clone::ImplicitClone for #ident {}
+    };
+    res.into()
+}

--- a/implicit-clone-derive/tests/function_attr_test.rs
+++ b/implicit-clone-derive/tests/function_attr_test.rs
@@ -1,0 +1,13 @@
+#[allow(dead_code)]
+#[test]
+fn tests_pass() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/function_component_attr/*-pass.rs");
+}
+
+#[allow(dead_code)]
+#[rustversion::attr(stable(1.64), test)]
+fn tests_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/function_component_attr/*-fail.rs");
+}

--- a/implicit-clone-derive/tests/function_component_attr/derive-fail.rs
+++ b/implicit-clone-derive/tests/function_component_attr/derive-fail.rs
@@ -1,0 +1,6 @@
+use implicit_clone::ImplicitClone;
+
+#[derive(ImplicitClone)]
+pub struct NotClonableStruct;
+
+fn main() {}

--- a/implicit-clone-derive/tests/function_component_attr/derive-fail.rs
+++ b/implicit-clone-derive/tests/function_component_attr/derive-fail.rs
@@ -3,4 +3,7 @@ use implicit_clone::ImplicitClone;
 #[derive(ImplicitClone)]
 pub struct NotClonableStruct;
 
+#[derive(ImplicitClone)]
+fn foo() {}
+
 fn main() {}

--- a/implicit-clone-derive/tests/function_component_attr/derive-fail.stderr
+++ b/implicit-clone-derive/tests/function_component_attr/derive-fail.stderr
@@ -1,3 +1,11 @@
+error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
+ --> tests/function_component_attr/derive-fail.rs:6:1
+  |
+6 | #[derive(ImplicitClone)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^ not applicable here
+7 | fn foo() {}
+  | ----------- not a `struct`, `enum` or `union`
+
 error[E0277]: the trait bound `NotClonableStruct: Clone` is not satisfied
  --> tests/function_component_attr/derive-fail.rs:3:10
   |

--- a/implicit-clone-derive/tests/function_component_attr/derive-fail.stderr
+++ b/implicit-clone-derive/tests/function_component_attr/derive-fail.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the trait bound `NotClonableStruct: Clone` is not satisfied
+ --> tests/function_component_attr/derive-fail.rs:3:10
+  |
+3 | #[derive(ImplicitClone)]
+  |          ^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NotClonableStruct`
+  |
+note: required by a bound in `ImplicitClone`
+ --> $WORKSPACE/src/lib.rs
+  |
+  | pub trait ImplicitClone: Clone {
+  |                          ^^^^^ required by this bound in `ImplicitClone`
+  = note: this error originates in the derive macro `ImplicitClone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `NotClonableStruct` with `#[derive(Clone)]`
+  |
+4 | #[derive(Clone)]
+  |

--- a/implicit-clone-derive/tests/function_component_attr/derive-pass.rs
+++ b/implicit-clone-derive/tests/function_component_attr/derive-pass.rs
@@ -1,0 +1,44 @@
+#![no_implicit_prelude]
+
+// Shadow primitives
+#[allow(non_camel_case_types)]
+pub struct bool;
+#[allow(non_camel_case_types)]
+pub struct char;
+#[allow(non_camel_case_types)]
+pub struct f32;
+#[allow(non_camel_case_types)]
+pub struct f64;
+#[allow(non_camel_case_types)]
+pub struct i128;
+#[allow(non_camel_case_types)]
+pub struct i16;
+#[allow(non_camel_case_types)]
+pub struct i32;
+#[allow(non_camel_case_types)]
+pub struct i64;
+#[allow(non_camel_case_types)]
+pub struct i8;
+#[allow(non_camel_case_types)]
+pub struct isize;
+#[allow(non_camel_case_types)]
+pub struct str;
+#[allow(non_camel_case_types)]
+pub struct u128;
+#[allow(non_camel_case_types)]
+pub struct u16;
+#[allow(non_camel_case_types)]
+pub struct u32;
+#[allow(non_camel_case_types)]
+pub struct u64;
+#[allow(non_camel_case_types)]
+pub struct u8;
+#[allow(non_camel_case_types)]
+pub struct usize;
+
+#[derive(Clone, ::implicit_clone::ImplicitClone)]
+struct ExampleStruct;
+
+fn main() {
+    let _ = ::implicit_clone::ImplicitClone::implicit_clone(&ExampleStruct);
+}

--- a/implicit-clone-derive/tests/function_component_attr/derive-pass.rs
+++ b/implicit-clone-derive/tests/function_component_attr/derive-pass.rs
@@ -1,50 +1,14 @@
-#![no_implicit_prelude]
+use implicit_clone::ImplicitClone;
 
-// Shadow primitives
-#[allow(non_camel_case_types)]
-pub struct bool;
-#[allow(non_camel_case_types)]
-pub struct char;
-#[allow(non_camel_case_types)]
-pub struct f32;
-#[allow(non_camel_case_types)]
-pub struct f64;
-#[allow(non_camel_case_types)]
-pub struct i128;
-#[allow(non_camel_case_types)]
-pub struct i16;
-#[allow(non_camel_case_types)]
-pub struct i32;
-#[allow(non_camel_case_types)]
-pub struct i64;
-#[allow(non_camel_case_types)]
-pub struct i8;
-#[allow(non_camel_case_types)]
-pub struct isize;
-#[allow(non_camel_case_types)]
-pub struct str;
-#[allow(non_camel_case_types)]
-pub struct u128;
-#[allow(non_camel_case_types)]
-pub struct u16;
-#[allow(non_camel_case_types)]
-pub struct u32;
-#[allow(non_camel_case_types)]
-pub struct u64;
-#[allow(non_camel_case_types)]
-pub struct u8;
-#[allow(non_camel_case_types)]
-pub struct usize;
-
-#[derive(Clone, ::implicit_clone::ImplicitClone)]
+#[derive(Clone, ImplicitClone)]
 struct ExampleStruct;
 
-#[derive(Clone, ::implicit_clone::ImplicitClone)]
+#[derive(Clone, ImplicitClone)]
 struct StructWithGenerics<T>(T);
 
-#[derive(Clone, ::implicit_clone::ImplicitClone)]
-struct StructWithGenericsWithBounds<T: ::std::cmp::PartialEq>(T);
+#[derive(Clone, ImplicitClone)]
+struct StructWithGenericsWithBounds<T: PartialEq>(T);
 
 fn main() {
-    let _ = ::implicit_clone::ImplicitClone::implicit_clone(&ExampleStruct);
+    let _ = ImplicitClone::implicit_clone(&ExampleStruct);
 }

--- a/implicit-clone-derive/tests/function_component_attr/derive-pass.rs
+++ b/implicit-clone-derive/tests/function_component_attr/derive-pass.rs
@@ -39,6 +39,12 @@ pub struct usize;
 #[derive(Clone, ::implicit_clone::ImplicitClone)]
 struct ExampleStruct;
 
+#[derive(Clone, ::implicit_clone::ImplicitClone)]
+struct StructWithGenerics<T>(T);
+
+#[derive(Clone, ::implicit_clone::ImplicitClone)]
+struct StructWithGenericsWithBounds<T: ::std::cmp::PartialEq>(T);
+
 fn main() {
     let _ = ::implicit_clone::ImplicitClone::implicit_clone(&ExampleStruct);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@ pub mod sync;
 /// Single-threaded version of immutable types.
 pub mod unsync;
 
+#[cfg(feature = "implicit-clone-derive")]
+pub use implicit_clone_derive::*;
+
 /// Marker trait for cheap-to-clone types that should be allowed to be cloned implicitly.
 ///
 /// Enables host libraries to have the same syntax as [`Copy`] while calling the [`Clone`]


### PR DESCRIPTION
I think it would be handy to have a derive macro for ImplicitClone so we don't have to write the entire impl all the time.