### PR TITLE
Restrict the dependency on `indexmap` to v2 only

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
           - stable
           - 1.64.0
         indexmap:
-          - 1.9.3
+          - 2.0.0
           - latest
         include:
           - os: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,9 +22,6 @@ jobs:
         rust:
           - stable
           - 1.64.0
-        indexmap:
-          - 2.0.0
-          - latest
         include:
           - os: ubuntu-latest
             rust: stable
@@ -43,11 +40,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           default: true
           override: true
-
-      - name: Change indexmap version
-        if: matrix.indexmap != 'latest'
-        run: |
-          cargo update -p indexmap --precise ${{ matrix.indexmap }}
 
       - name: cargo test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ derive = ["implicit-clone-derive"]
 
 [dependencies]
 implicit-clone-derive = { version = "0.1", optional = true, path = "./implicit-clone-derive" }
-indexmap = { version = ">= 1, <= 2", optional = true }
+indexmap = { version = "2", optional = true }
 serde = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/implicit-clone-derive/Cargo.toml
+++ b/implicit-clone-derive/Cargo.toml
@@ -21,5 +21,5 @@ syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
 implicit-clone = { path = ".." }
-trybuild = "1"
+trybuild = "=1.0.89"
 rustversion = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,7 @@ mod test {
     #[test]
     fn custom() {
         #[derive(Clone)]
+        #[allow(dead_code)]
         struct ImplicitCloneType;
 
         impl ImplicitClone for ImplicitCloneType {}

--- a/src/map.rs
+++ b/src/map.rs
@@ -162,10 +162,10 @@ impl<K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'sta
     ///
     /// Computes in **O(1)** time (average).
     #[inline]
-    pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<V>
+    pub fn get<Q>(&self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         match self {
             Self::Static(a) => a
@@ -181,10 +181,10 @@ impl<K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'sta
     ///
     /// Computes in **O(1)** time (average).
     #[inline]
-    pub fn get_key_value<Q: ?Sized>(&self, key: &Q) -> Option<(K, V)>
+    pub fn get_key_value<Q>(&self, key: &Q) -> Option<(K, V)>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         match self {
             Self::Static(a) => a.iter().find(|(k, _)| k.borrow() == key).cloned(),
@@ -194,10 +194,10 @@ impl<K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'sta
 
     /// Return item index, key and value
     #[inline]
-    pub fn get_full<Q: ?Sized>(&self, key: &Q) -> Option<(usize, K, V)>
+    pub fn get_full<Q>(&self, key: &Q) -> Option<(usize, K, V)>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         match self {
             Self::Static(a) => a
@@ -225,10 +225,10 @@ impl<K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'sta
     ///
     /// Computes in **O(1)** time (average).
     #[inline]
-    pub fn get_index_of<Q: ?Sized>(&self, key: &Q) -> Option<usize>
+    pub fn get_index_of<Q>(&self, key: &Q) -> Option<usize>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         match self {
             Self::Static(a) => a
@@ -243,10 +243,10 @@ impl<K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'sta
     ///
     /// Computes in **O(1)** time (average).
     #[inline]
-    pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         match self {
             Self::Static(a) => a.iter().any(|(k, _)| k.borrow() == key),


### PR DESCRIPTION
Allowing both indexmap v1 & v2 causes a lot of annoyance when the version of indexmap used by this crate and the one used by other crates in the dependency tree don't match.
See also https://github.com/yewstack/yew/issues/3659