### PR TITLE
Remove Single variant of IArray to avoid infinite recursion

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/src/array.rs
+++ b/src/array.rs
@@ -481,10 +481,10 @@ mod test_array {
     #[test]
     fn recursion() {
         #[derive(Clone)]
-        struct Node {
-            children: IArray<Node>,
+        struct _Node {
+            _children: IArray<_Node>,
         }
 
-        impl ImplicitClone for Node {}
+        impl ImplicitClone for _Node {}
     }
 }


### PR DESCRIPTION
Fixes #64
Related to #38
