### PR TITLE
Implement IntoIterator for IMap and IArray via their refs

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -110,47 +110,12 @@ impl<T: ImplicitClone + 'static, const N: usize> From<[T; N]> for IArray<T> {
     }
 }
 
-/// An iterator over the cloned elements of an `IArray`.
-#[derive(Debug)]
-pub struct IArrayIntoIter<T: ImplicitClone + 'static> {
-    array: IArray<T>,
-    left: usize,
-    right: usize,
-}
-
-impl<T: ImplicitClone + 'static> IntoIterator for IArray<T> {
+impl<'a, T: ImplicitClone + 'static> IntoIterator for &'a IArray<T> {
     type Item = T;
-    type IntoIter = IArrayIntoIter<T>;
+    type IntoIter = std::iter::Cloned<std::slice::Iter<'a, T>>;
 
     fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
-        IArrayIntoIter {
-            left: 0,
-            right: self.len(),
-            array: self,
-        }
-    }
-}
-
-impl<T: ImplicitClone + 'static> Iterator for IArrayIntoIter<T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.left >= self.right {
-            return None;
-        }
-        let item = &self.array[self.left];
-        self.left += 1;
-        Some(item.clone())
-    }
-}
-
-impl<T: ImplicitClone + 'static> DoubleEndedIterator for IArrayIntoIter<T> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.left >= self.right {
-            return None;
-        }
-        self.right -= 1;
-        Some(self.array[self.right].clone())
+        self.iter().cloned()
     }
 }
 
@@ -333,7 +298,7 @@ impl<T: ImplicitClone + 'static> IArray<T> {
     }
 }
 
-impl<'a, T, U, const N: usize> PartialEq<&'a [U; N]> for IArray<T>
+impl<T, U, const N: usize> PartialEq<&[U; N]> for IArray<T>
 where
     T: PartialEq<U> + ImplicitClone,
 {
@@ -369,7 +334,7 @@ where
     }
 }
 
-impl<'a, T, U> PartialEq<&'a [U]> for IArray<T>
+impl<T, U> PartialEq<&[U]> for IArray<T>
 where
     T: PartialEq<U> + ImplicitClone,
 {
@@ -490,7 +455,7 @@ mod test_array {
     }
 
     #[test]
-    fn into_iter() {
+    fn iterators() {
         let array = IArray::Static(&[1, 2, 3]);
         assert_eq!(array.iter().next().unwrap(), &1);
         assert_eq!(array.into_iter().next().unwrap(), 1);

--- a/src/map.rs
+++ b/src/map.rs
@@ -308,14 +308,25 @@ impl<'a, K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 
     }
 }
 
-impl<'a, K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'static>
-    DoubleEndedIterator for IMapIter<'a, K, V>
+impl<K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'static>
+    DoubleEndedIterator for IMapIter<'_, K, V>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         match self {
             Self::Slice(it) => it.next_back().map(|(k, v)| (k, v)),
             Self::Map(it) => it.next_back(),
         }
+    }
+}
+
+impl<'a, K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'static>
+    IntoIterator for &'a IMap<K, V>
+{
+    type Item = (K, V);
+    type IntoIter = std::iter::Map<IMapIter<'a, K, V>, fn((&'a K, &'a V)) -> (K, V)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter().map(|(k, v)| (k.clone(), v.clone()))
     }
 }
 
@@ -338,8 +349,8 @@ impl<'a, K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 
     }
 }
 
-impl<'a, K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'static>
-    DoubleEndedIterator for IMapKeys<'a, K, V>
+impl<K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'static>
+    DoubleEndedIterator for IMapKeys<'_, K, V>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         match self {
@@ -368,8 +379,8 @@ impl<'a, K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 
     }
 }
 
-impl<'a, K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'static>
-    DoubleEndedIterator for IMapValues<'a, K, V>
+impl<K: Eq + Hash + ImplicitClone + 'static, V: PartialEq + ImplicitClone + 'static>
+    DoubleEndedIterator for IMapValues<'_, K, V>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         match self {
@@ -471,5 +482,14 @@ mod test_map {
     fn from() {
         let x: IMap<u32, u32> = IMap::Static(&[]);
         let _out = IMap::from(&x);
+    }
+
+    #[test]
+    fn iterators() {
+        let map = IMap::Static(&[(1, 10), (2, 20), (3, 30)]);
+        assert_eq!(map.iter().next().unwrap(), (&1, &10));
+        assert_eq!(map.keys().next().unwrap(), &1);
+        assert_eq!(map.values().next().unwrap(), &10);
+        assert_eq!(map.into_iter().next().unwrap(), (1, 10));
     }
 }


### PR DESCRIPTION
This PR is a variant of implementing `IntoIterator` via an `&'a` reference to the respective collections (`IArray`, `IMap`).

This means the iterator may not outlive the instance. For example, you may not return the iterator from a function, if the supplied `IArray` does not outlive the function scope:

```rust
fn first<'a>(arr: &'a IArray<i32>) -> impl Iterator<Item = i32> + 'a { // note that implemented object lives as long as that reference - it borrows `arr`
    arr.into_iter() // ok in any solution
}

fn second() -> impl Iterator<Item = i32> {
    let arr = IArray::...;
    arr.into_iter() // cannot happen, as `IArray` will be `Drop`ped at the end of this scope
}
```

The `IArray` implementation is rewritten to the same approach for consistency. Breaking change.

Closes #69 because the two approaches are disjoint.