### PR TITLE
Swap `From<Cow<'static, str>>` with `From<Cow<'_, str>>` for `IString`

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -87,10 +87,10 @@ impl From<Rc<str>> for IString {
     }
 }
 
-impl From<Cow<'static, str>> for IString {
-    fn from(cow: Cow<'static, str>) -> Self {
+impl From<Cow<'_, str>> for IString {
+    fn from(cow: Cow<'_, str>) -> Self {
         match cow {
-            Cow::Borrowed(s) => IString::Static(s),
+            Cow::Borrowed(s) => s.into(),
             Cow::Owned(s) => s.into(),
         }
     }


### PR DESCRIPTION
Same as #67.

Reason being [`OsStr::to_string_lossy`](https://doc.rust-lang.org/std/ffi/struct.OsStr.html#method.to_string_lossy) returns `Cow<'_, str>` for whatever reason, preventing `.into()` the very same way having only `From<&'static str>` did - with the confusing errors that point to wrong places and do not describe anything much useful.